### PR TITLE
Secure WiFi config

### DIFF
--- a/esp32-cam/CameraWebServer/CameraWebServer.ino
+++ b/esp32-cam/CameraWebServer/CameraWebServer.ino
@@ -15,11 +15,14 @@ DHT dht(DHTPIN, DHTTYPE);
 
 #define FLAME_PIN 14 // Flame sensor 신호선 연결 핀
 
+// WiFi credentials are loaded from wifi_config.h
+#include "wifi_config.h"
+
 // ===========================
-// WiFi 접속 정보 입력 (자신의 네트워크 정보로 변경)
+// WiFi 접속 정보는 wifi_config.h에서 정의된 상수를 사용
 // ===========================
-const char *ssid = "GalaxyS224896";      // WiFi 네트워크 이름(SSID)
-const char *password = "71503569";  // WiFi 비밀번호
+const char *ssid = WIFI_SSID;      // WiFi 네트워크 이름(SSID)
+const char *password = WIFI_PASSWORD;  // WiFi 비밀번호
 
 // 카메라 서버 시작 함수 선언 (구현은 별도)
 void startCameraServer();

--- a/esp32-cam/CameraWebServer/README.md
+++ b/esp32-cam/CameraWebServer/README.md
@@ -1,3 +1,15 @@
 # esp32-cam
 File - preferences 을 클릭하여 Sketchbook location의 경로를 확인하고, 거기에 두 폴더를 삽입해주세요.
 기존에 사용하던 라이브러리가 있을경우, library폴더는 제외하고, 따로 받으시면 됩니다.
+
+## WiFi 설정
+
+`CameraWebServer.ino`에서는 `wifi_config.h` 파일을 포함하여 WiFi 정보를 불러옵니다.
+해당 파일에서 다음 두 상수를 원하는 값으로 수정하세요.
+
+```C
+#define WIFI_SSID      "YOUR_SSID"
+#define WIFI_PASSWORD  "YOUR_PASSWORD"
+```
+
+스케치를 컴파일하기 전에 `wifi_config.h`가 같은 폴더에 존재해야 합니다.

--- a/esp32-cam/CameraWebServer/wifi_config.h
+++ b/esp32-cam/CameraWebServer/wifi_config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Replace these with your WiFi credentials
+#define WIFI_SSID      "YOUR_SSID"
+#define WIFI_PASSWORD  "YOUR_PASSWORD"


### PR DESCRIPTION
## Summary
- avoid hardcoding WiFi credentials in `CameraWebServer.ino`
- load credentials from new `wifi_config.h`
- document how to set WiFi info in README

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433e2b56a48323802399214acc6124